### PR TITLE
Corrects faulty installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Productionize Spinnaker via Terraform
 
 ```
-terraform init https://github.com/moondev/spinnaker-productionized
+terraform init github.com/moondev/spinnaker-productionized
 terraform apply
 ```


### PR DESCRIPTION
As per the title. the current terraform call fails to recognize a github repository from the URL.